### PR TITLE
로그인 회원가입 페이지 만들기

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="PrettierConfiguration">
     <option name="myConfigurationMode" value="AUTOMATIC" />
+    <option name="myRunOnSave" value="true" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,13 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment=":wrench: .idea 수정">
-      <change beforePath="$PROJECT_DIR$/.idea/prettier.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/prettier.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/api/auth.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/api/auth.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/lib/config.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/config.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/routes/+page.svelte" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/+page.svelte" afterDir="false" />
-    </list>
+    <list default="true" id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment=":wrench: .idea 수정" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -86,27 +80,27 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "Node.js.이름이 지정되지 않았습니다.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "code.cleanup.on.save": "true",
-    "git-widget-placeholder": "로그인-회원가입-페이지-만들기",
-    "last_opened_file_path": "/Users/kdelphinus/BoardGameLog-Frontend/src/routes/signup",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "npm.run dev.executor": "Run",
-    "rearrange.code.on.save": "true",
-    "settings.editor.selected.configurable": "actions.on.save",
-    "ts.external.directory.path": "/Users/kdelphinus/BoardGameLog-Frontend/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;Node.js.이름이 지정되지 않았습니다.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;code.cleanup.on.save&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;로그인-회원가입-페이지-만들기&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/kdelphinus/BoardGameLog-Frontend/src/routes/signup&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;npm.run dev.executor&quot;: &quot;Run&quot;,
+    &quot;rearrange.code.on.save&quot;: &quot;true&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;actions.on.save&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/kdelphinus/BoardGameLog-Frontend/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src/routes/signup" />
@@ -147,7 +141,7 @@
       <workItem from="1745658084230" duration="4947000" />
       <workItem from="1746005287910" duration="11477000" />
       <workItem from="1746089041865" duration="5869000" />
-      <workItem from="1746116410928" duration="1253000" />
+      <workItem from="1746116410928" duration="1456000" />
     </task>
     <task id="LOCAL-00001" summary=":wrench: .idea 생성">
       <option name="closed" value="true" />
@@ -229,7 +223,39 @@
       <option name="project" value="LOCAL" />
       <updated>1746035038455</updated>
     </task>
-    <option name="localTasksCounter" value="11" />
+    <task id="LOCAL-00011" summary=":art: log api 요청 동작을 분리">
+      <option name="closed" value="true" />
+      <created>1746117794881</created>
+      <option name="number" value="00011" />
+      <option name="presentableId" value="LOCAL-00011" />
+      <option name="project" value="LOCAL" />
+      <updated>1746117794882</updated>
+    </task>
+    <task id="LOCAL-00012" summary=":recycle: config 파일 사용하도록 수정">
+      <option name="closed" value="true" />
+      <created>1746117837247</created>
+      <option name="number" value="00012" />
+      <option name="presentableId" value="LOCAL-00012" />
+      <option name="project" value="LOCAL" />
+      <updated>1746117837247</updated>
+    </task>
+    <task id="LOCAL-00013" summary=":sparkles: log 상세 페이지 단순 구현">
+      <option name="closed" value="true" />
+      <created>1746117854543</created>
+      <option name="number" value="00013" />
+      <option name="presentableId" value="LOCAL-00013" />
+      <option name="project" value="LOCAL" />
+      <updated>1746117854543</updated>
+    </task>
+    <task id="LOCAL-00014" summary=":wrench: .idea 수정">
+      <option name="closed" value="true" />
+      <created>1746117863947</created>
+      <option name="number" value="00014" />
+      <option name="presentableId" value="LOCAL-00014" />
+      <option name="project" value="LOCAL" />
+      <updated>1746117863947</updated>
+    </task>
+    <option name="localTasksCounter" value="15" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -255,6 +281,9 @@
     <MESSAGE value=":sparkles: 기본 페이지 생성" />
     <MESSAGE value=":wrench: gameLog api 추가" />
     <MESSAGE value=":label: type 파일 분리" />
+    <MESSAGE value=":art: log api 요청 동작을 분리" />
+    <MESSAGE value=":recycle: config 파일 사용하도록 수정" />
+    <MESSAGE value=":sparkles: log 상세 페이지 단순 구현" />
     <MESSAGE value=":wrench: .idea 수정" />
     <option name="LAST_COMMIT_MESSAGE" value=":wrench: .idea 수정" />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,13 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment=":art: 백엔드 api url을 apiURL로 묶어서 선언" />
+    <list default="true" id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment=":wrench: .idea 수정">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/config.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/config.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/routes/+page.svelte" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/+page.svelte" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/routes/login/+page.svelte" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/login/+page.svelte" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/routes/signup/+page.svelte" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/signup/+page.svelte" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -27,12 +33,12 @@
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
-  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
-  "lastFilter": {
-    "state": "OPEN",
-    "assignee": "Kdelphinus"
+  <component name="GitHubPullRequestSearchHistory">{
+  &quot;lastFilter&quot;: {
+    &quot;state&quot;: &quot;OPEN&quot;,
+    &quot;assignee&quot;: &quot;Kdelphinus&quot;
   }
-}]]></component>
+}</component>
   <component name="GitToolBoxStore">
     <option name="recentBranches">
       <RecentBranches>
@@ -62,16 +68,16 @@
       </RecentBranches>
     </option>
   </component>
-  <component name="GithubPullRequestsUISettings"><![CDATA[{
-  "selectedUrlAndAccountId": {
-    "url": "https://github.com/Kdelphinus/BoardGameLog-Frontend.git",
-    "accountId": "e37bec06-ffd7-4016-a76f-3fdcd32054a1"
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;https://github.com/Kdelphinus/BoardGameLog-Frontend.git&quot;,
+    &quot;accountId&quot;: &quot;e37bec06-ffd7-4016-a76f-3fdcd32054a1&quot;
   }
-}]]></component>
-  <component name="ProjectColorInfo"><![CDATA[{
-  "customColor": "",
-  "associatedIndex": 5
-}]]></component>
+}</component>
+  <component name="ProjectColorInfo">{
+  &quot;customColor&quot;: &quot;&quot;,
+  &quot;associatedIndex&quot;: 5
+}</component>
   <component name="ProjectId" id="2vqzdrShchd30MMsMdeMipiQq0y" />
   <component name="ProjectLevelVcsManager">
     <ConfirmationsSetting value="1" id="Add" />
@@ -80,25 +86,25 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "Node.js.이름이 지정되지 않았습니다.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "로그인-회원가입-페이지-만들기",
-    "last_opened_file_path": "/Users/kdelphinus/BoardGameLog-Frontend/src/routes/signup",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "npm.run dev.executor": "Run",
-    "settings.editor.selected.configurable": "preferences.keymap",
-    "ts.external.directory.path": "/Users/kdelphinus/BoardGameLog-Frontend/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;Node.js.이름이 지정되지 않았습니다.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;로그인-회원가입-페이지-만들기&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/kdelphinus/BoardGameLog-Frontend/src/routes/signup&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;npm.run dev.executor&quot;: &quot;Run&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/kdelphinus/BoardGameLog-Frontend/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src/routes/signup" />
@@ -130,7 +136,11 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1744887483979</updated>
-      <workItem from="1744887488402" duration="14309000" />
+      <workItem from="1744887488402" duration="14359000" />
+      <workItem from="1745488378549" duration="2608000" />
+      <workItem from="1745571386744" duration="65000" />
+      <workItem from="1745658084230" duration="4947000" />
+      <workItem from="1746005287910" duration="11199000" />
     </task>
     <task id="LOCAL-00001" summary=":wrench: .idea 생성">
       <option name="closed" value="true" />
@@ -148,15 +158,44 @@
       <option name="project" value="LOCAL" />
       <updated>1744911956966</updated>
     </task>
-    <option name="localTasksCounter" value="3" />
+    <task id="LOCAL-00003" summary=":sparkles: 로그인 및 회원가입 기능 추가">
+      <option name="closed" value="true" />
+      <created>1744912004227</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1744912004227</updated>
+    </task>
+    <task id="LOCAL-00004" summary=":wrench: .idea 수정">
+      <option name="closed" value="true" />
+      <created>1744912019713</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1744912019713</updated>
+    </task>
+    <option name="localTasksCounter" value="5" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
   </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
   <component name="VcsManagerConfiguration">
     <MESSAGE value=":wrench: .idea 생성" />
     <MESSAGE value=":art: 백엔드 api url을 apiURL로 묶어서 선언" />
-    <option name="LAST_COMMIT_MESSAGE" value=":art: 백엔드 api url을 apiURL로 묶어서 선언" />
+    <MESSAGE value=":sparkles: 로그인 및 회원가입 기능 추가" />
+    <MESSAGE value=":wrench: .idea 수정" />
+    <option name="LAST_COMMIT_MESSAGE" value=":wrench: .idea 수정" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,12 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="AuthForm" />
+        <option value="+page" />
+        <option value="TypeScript File" />
+      </list>
+    </option>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="main" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
+  "lastFilter": {
+    "state": "OPEN",
+    "assignee": "Kdelphinus"
+  }
+}]]></component>
+  <component name="GitToolBoxStore">
+    <option name="recentBranches">
+      <RecentBranches>
+        <option name="branchesForRepo">
+          <list>
+            <RecentBranchesForRepo>
+              <option name="branches">
+                <list>
+                  <RecentBranch>
+                    <option name="branchName" value="로그인-회원가입-페이지-만들기" />
+                    <option name="lastUsedInstant" value="1744887936" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="develop" />
+                    <option name="lastUsedInstant" value="1744887674" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="main" />
+                    <option name="lastUsedInstant" value="1744887670" />
+                  </RecentBranch>
+                </list>
+              </option>
+              <option name="repositoryRootUrl" value="file://$PROJECT_DIR$" />
+            </RecentBranchesForRepo>
+          </list>
+        </option>
+      </RecentBranches>
+    </option>
+  </component>
+  <component name="GithubPullRequestsUISettings"><![CDATA[{
+  "selectedUrlAndAccountId": {
+    "url": "https://github.com/Kdelphinus/BoardGameLog-Frontend.git",
+    "accountId": "e37bec06-ffd7-4016-a76f-3fdcd32054a1"
+  }
+}]]></component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "customColor": "",
+  "associatedIndex": 5
+}]]></component>
+  <component name="ProjectId" id="2vqzdrShchd30MMsMdeMipiQq0y" />
+  <component name="ProjectLevelVcsManager">
+    <ConfirmationsSetting value="1" id="Add" />
+  </component>
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "Node.js.이름이 지정되지 않았습니다.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "로그인-회원가입-페이지-만들기",
+    "last_opened_file_path": "/Users/kdelphinus/BoardGameLog-Frontend/src/routes/signup",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "npm.run dev.executor": "Run",
+    "settings.editor.selected.configurable": "preferences.keymap",
+    "ts.external.directory.path": "/Users/kdelphinus/BoardGameLog-Frontend/node_modules/typescript/lib",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
+  <component name="RecentsManager">
+    <key name="CopyFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/src/routes/signup" />
+    </key>
+  </component>
+  <component name="RunManager">
+    <configuration name="run dev" type="js.build_tools.npm" nameIsGenerated="true">
+      <package-json value="$PROJECT_DIR$/package.json" />
+      <command value="run" />
+      <scripts>
+        <script value="dev" />
+      </scripts>
+      <node-interpreter value="project" />
+      <envs />
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-f27c65a3e318-JavaScript-WS-251.23774.424" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="디폴트 작업">
+      <changelist id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment="" />
+      <created>1744887483979</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1744887483979</updated>
+      <workItem from="1744887488402" duration="14068000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,11 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment=":wrench: .idea 수정">
+      <change beforePath="$PROJECT_DIR$/.idea/prettier.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/prettier.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/lib/api/auth.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/api/auth.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/lib/config.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/lib/config.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/routes/+page.svelte" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/+page.svelte" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/routes/login/+page.svelte" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/login/+page.svelte" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/routes/signup/+page.svelte" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/signup/+page.svelte" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -86,28 +86,33 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;Node.js.이름이 지정되지 않았습니다.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;로그인-회원가입-페이지-만들기&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/kdelphinus/BoardGameLog-Frontend/src/routes/signup&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;npm.run dev.executor&quot;: &quot;Run&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/kdelphinus/BoardGameLog-Frontend/node_modules/typescript/lib&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "Node.js.이름이 지정되지 않았습니다.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "code.cleanup.on.save": "true",
+    "git-widget-placeholder": "로그인-회원가입-페이지-만들기",
+    "last_opened_file_path": "/Users/kdelphinus/BoardGameLog-Frontend/src/routes/signup",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "npm.run dev.executor": "Run",
+    "rearrange.code.on.save": "true",
+    "settings.editor.selected.configurable": "actions.on.save",
+    "ts.external.directory.path": "/Users/kdelphinus/BoardGameLog-Frontend/node_modules/typescript/lib",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src/routes/signup" />
+    </key>
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/src/routes/posts" />
     </key>
   </component>
   <component name="RunManager">
@@ -140,7 +145,9 @@
       <workItem from="1745488378549" duration="2608000" />
       <workItem from="1745571386744" duration="65000" />
       <workItem from="1745658084230" duration="4947000" />
-      <workItem from="1746005287910" duration="11199000" />
+      <workItem from="1746005287910" duration="11477000" />
+      <workItem from="1746089041865" duration="5869000" />
+      <workItem from="1746116410928" duration="1253000" />
     </task>
     <task id="LOCAL-00001" summary=":wrench: .idea 생성">
       <option name="closed" value="true" />
@@ -174,7 +181,55 @@
       <option name="project" value="LOCAL" />
       <updated>1744912019713</updated>
     </task>
-    <option name="localTasksCounter" value="5" />
+    <task id="LOCAL-00005" summary=":sparkles: login, signup 백엔드와 연결">
+      <option name="closed" value="true" />
+      <created>1746034932573</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1746034932573</updated>
+    </task>
+    <task id="LOCAL-00006" summary=":art: login, signup 동작 분리">
+      <option name="closed" value="true" />
+      <created>1746034947440</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1746034947440</updated>
+    </task>
+    <task id="LOCAL-00007" summary=":sparkles: 기본 페이지 생성">
+      <option name="closed" value="true" />
+      <created>1746034967073</created>
+      <option name="number" value="00007" />
+      <option name="presentableId" value="LOCAL-00007" />
+      <option name="project" value="LOCAL" />
+      <updated>1746034967073</updated>
+    </task>
+    <task id="LOCAL-00008" summary=":wrench: gameLog api 추가">
+      <option name="closed" value="true" />
+      <created>1746035001827</created>
+      <option name="number" value="00008" />
+      <option name="presentableId" value="LOCAL-00008" />
+      <option name="project" value="LOCAL" />
+      <updated>1746035001827</updated>
+    </task>
+    <task id="LOCAL-00009" summary=":label: type 파일 분리">
+      <option name="closed" value="true" />
+      <created>1746035020942</created>
+      <option name="number" value="00009" />
+      <option name="presentableId" value="LOCAL-00009" />
+      <option name="project" value="LOCAL" />
+      <updated>1746035020942</updated>
+    </task>
+    <task id="LOCAL-00010" summary=":wrench: .idea 수정">
+      <option name="closed" value="true" />
+      <created>1746035038455</created>
+      <option name="number" value="00010" />
+      <option name="presentableId" value="LOCAL-00010" />
+      <option name="project" value="LOCAL" />
+      <updated>1746035038455</updated>
+    </task>
+    <option name="localTasksCounter" value="11" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -195,6 +250,11 @@
     <MESSAGE value=":wrench: .idea 생성" />
     <MESSAGE value=":art: 백엔드 api url을 apiURL로 묶어서 선언" />
     <MESSAGE value=":sparkles: 로그인 및 회원가입 기능 추가" />
+    <MESSAGE value=":sparkles: login, signup 백엔드와 연결" />
+    <MESSAGE value=":art: login, signup 동작 분리" />
+    <MESSAGE value=":sparkles: 기본 페이지 생성" />
+    <MESSAGE value=":wrench: gameLog api 추가" />
+    <MESSAGE value=":label: type 파일 분리" />
     <MESSAGE value=":wrench: .idea 수정" />
     <option name="LAST_COMMIT_MESSAGE" value=":wrench: .idea 수정" />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-    </list>
+    <list default="true" id="4cd11325-4881-49d9-a13c-37d9a02946f1" name="변경" comment=":art: 백엔드 api url을 apiURL로 묶어서 선언" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -132,11 +130,33 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1744887483979</updated>
-      <workItem from="1744887488402" duration="14068000" />
+      <workItem from="1744887488402" duration="14309000" />
     </task>
+    <task id="LOCAL-00001" summary=":wrench: .idea 생성">
+      <option name="closed" value="true" />
+      <created>1744911876338</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1744911876338</updated>
+    </task>
+    <task id="LOCAL-00002" summary=":art: 백엔드 api url을 apiURL로 묶어서 선언">
+      <option name="closed" value="true" />
+      <created>1744911956966</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1744911956966</updated>
+    </task>
+    <option name="localTasksCounter" value="3" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value=":wrench: .idea 생성" />
+    <MESSAGE value=":art: 백엔드 api url을 apiURL로 묶어서 선언" />
+    <option name="LAST_COMMIT_MESSAGE" value=":art: 백엔드 api url을 apiURL로 묶어서 선언" />
   </component>
 </project>

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,13 +1,10 @@
 import { auth } from '$lib/stores/auth';
+import { apiURL } from '$lib/config';
 import type { LoginPayload, SignUpPayload } from '$lib/types';
-
-const BASE_URL = import.meta.env.VITE_BACKEND_URL;
-const API_VERSION = import.meta.env.VITE_API_VERSION;
-const API_ROOT = `${BASE_URL}/api/${API_VERSION}/users`;
 
 export async function login({ username, password }: LoginPayload) {
 	const body = new URLSearchParams({ username, password });
-	const response = await fetch(`${API_ROOT}/login`, {
+	const response = await fetch(apiURL['user']['login'], {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded'
@@ -26,13 +23,13 @@ export async function login({ username, password }: LoginPayload) {
 
 export async function signup(payload: SignUpPayload) {
 	const jsonData = {
-		'name': payload.username,
-		'email': payload.email,
-		'password': payload.password,
-		'check_password': payload.confirmPassword
+		name: payload.username,
+		email: payload.email,
+		password: payload.password,
+		check_password: payload.confirmPassword
 	};
 
-	const response = await fetch(`${API_ROOT}/create`, {
+	const response = await fetch(apiURL['user']['signup'], {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json'

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,46 @@
+import { auth } from '$lib/stores/auth';
+import type { LoginPayload, SignUpPayload } from '$lib/types';
+
+const BASE_URL = import.meta.env.VITE_BACKEND_URL;
+const API_VERSION = import.meta.env.VITE_API_VERSION;
+const API_ROOT = `${BASE_URL}/api/${API_VERSION}/users`;
+
+export async function login({ username, password }: LoginPayload) {
+	const body = new URLSearchParams({ username, password });
+	const response = await fetch(`${API_ROOT}/login`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded'
+		},
+		body
+	});
+
+	const data = await response.json();
+	if (!response.ok) throw new Error(data?.detail || 'Login failed');
+	if (data.access_token && data.name) {
+		auth.login(data.access_token, data.name); // 로그인 성공 시 저장
+	}
+
+	return data;
+}
+
+export async function signup(payload: SignUpPayload) {
+	const jsonData = {
+		'name': payload.username,
+		'email': payload.email,
+		'password': payload.password,
+		'check_password': payload.confirmPassword
+	};
+
+	const response = await fetch(`${API_ROOT}/create`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify(jsonData)
+	});
+
+	const data = await response.json();
+	if (!response.ok) throw new Error(data?.detail || 'Signup failed');
+	return data;
+}

--- a/src/lib/api/logs.ts
+++ b/src/lib/api/logs.ts
@@ -1,0 +1,24 @@
+import { apiURL } from '$lib/config';
+import type { Post } from '$lib/types';
+
+export async function getLogs(): Promise<Post[]> {
+	const response = await fetch(apiURL['gameLog']['list'], {
+		method: 'GET'
+	});
+
+	const data = await response.json();
+	if (!response.ok) throw new Error(data?.detail || '게시글을 불러오지 못했습니다.');
+	return data;
+}
+
+
+export async function getParticularLog(postId: string | undefined): Promise<Post> {
+	if (postId === undefined) throw new Error();
+	const response = await fetch(`${apiURL['gameLog']['particular']}/${postId}`, {
+		method: 'GET'
+	});
+
+	const data = await response.json();
+	if (!response.ok) throw new Error(data?.detail || '게시글을 불러오지 못했습니다.');
+	return data;
+}

--- a/src/lib/components/AuthForm.svelte
+++ b/src/lib/components/AuthForm.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	let { type, onSubmit } = $props();
+
+	// 반응적으로 쓰일 변수는 $state()로 감싸줘야 함
+	let username = $state('');
+	let email = $state('');
+	let password = $state('');
+	let confirmPassword = $state('');
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();  // fetch 전에 페이지 reload 되는 것 방지
+
+		if (type === 'signup' && password !== confirmPassword) {
+			alert('비밀번호가 일치하지 않습니다!');
+			return;
+		}
+
+		const payload =
+			type === 'signup'
+				? { username, email, password, confirmPassword }
+				: { username, password };
+
+		await onSubmit(payload); // 상위에서 전달받은 함수 실행
+	}
+</script>
+
+<!--prevent는 페이지 리로딩을 막고 우리가 정의한 함수만 실행되도록 설정-->
+<form
+	class="flex flex-col gap-4 max-w-md mx-auto mt-20 p-6 border border-gray-200 shadow-sm rounded-lg"
+	onsubmit={handleSubmit}
+>
+	<h1 class="text-2xl font-bold mb-2 text-center">
+		{type === 'login' ? '로그인' : '회원가입'}
+	</h1>
+
+	<input
+		type="text"
+		placeholder="닉네임"
+		bind:value={username}
+		class="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+		required
+	/>
+
+	{#if type === 'signup'}
+		<input
+			type="email"
+			placeholder="이메일"
+			bind:value={email}
+			class="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+			required
+		/>
+	{/if}
+
+	<input
+		type="password"
+		placeholder="비밀번호"
+		bind:value={password}
+		class="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+		required
+	/>
+
+	{#if type === 'signup'}
+		<input
+			type="password"
+			placeholder="비밀번호 확인"
+			bind:value={confirmPassword}
+			class="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+			required
+		/>
+	{/if}
+
+	<button
+		type="submit"
+		class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-md transition duration-200"
+	>
+		{type === 'login' ? '로그인' : '회원가입'}
+	</button>
+</form>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,21 @@
+export const backendURL = import.meta.env.VITE_BACKEND_URL
+export const apiVersion = import.meta.env.VITE_API_VERSION
+
+export const apiURL = {
+	user: {
+		login: `${backendURL}/api/${apiVersion}/users/login`,
+		signup: `${backendURL}/api/${apiVersion}/users/create`,
+		refresh: `${backendURL}/api/${apiVersion}/users/refresh`,
+		logout: `${backendURL}/api/${apiVersion}/users/logout`,
+		resetPassword: `${backendURL}/api/${apiVersion}/users/reset-password`,
+		resetPasswordConfirm: `${backendURL}/api/${apiVersion}/users/reset-password/confirm`,
+		me: `${backendURL}/api/${apiVersion}/users/me`,
+		list: `${backendURL}/api/${apiVersion}/users/list`,
+		listDeactivate: `${backendURL}/api/${apiVersion}/users/list/deactivate`,
+		update: `${backendURL}/api/${apiVersion}/users/patch`,
+		updateDeactivate: `${backendURL}/api/${apiVersion}/users/deactivate`,
+		restore: `${backendURL}/api/${apiVersion}/users/restore`,
+		restoreConfirm: `${backendURL}/api/${apiVersion}/users/restore/confirm`,
+		delete: `${backendURL}/api/${apiVersion}/users/delete`,
+	},
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,4 +18,11 @@ export const apiURL = {
 		restoreConfirm: `${backendURL}/api/${apiVersion}/users/restore/confirm`,
 		delete: `${backendURL}/api/${apiVersion}/users/delete`,
 	},
+	gameLog: {
+		list: `${backendURL}/api/${apiVersion}/game_logs/list`,
+		my: `${backendURL}/api/${apiVersion}/game_logs/list/my`,
+		create: `${backendURL}/api/${apiVersion}/game_logs/create`,
+		update: `${backendURL}/api/${apiVersion}/game_logs/patch/my`,
+		delete: `${backendURL}/api/${apiVersion}/game_logs/delete/my`,
+	}
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,6 +20,7 @@ export const apiURL = {
 	},
 	gameLog: {
 		list: `${backendURL}/api/${apiVersion}/game_logs/list`,
+		particular: `${backendURL}/api/${apiVersion}/game_logs/list/log`,
 		my: `${backendURL}/api/${apiVersion}/game_logs/list/my`,
 		create: `${backendURL}/api/${apiVersion}/game_logs/create`,
 		update: `${backendURL}/api/${apiVersion}/game_logs/patch/my`,

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -1,0 +1,62 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+import type { AuthState } from '$lib/types';
+
+const TOKEN_KEY = 'access_token';
+const NAME_KEY = 'name';
+
+function createAuthStore() {
+	const initialToken = browser ? localStorage.getItem(TOKEN_KEY) : null;
+	const initialName = browser ? localStorage.getItem(NAME_KEY) : null;
+
+	const { subscribe, set, update } = writable<AuthState>({
+		isLoggedIn: !!initialToken,
+		accessToken: initialToken,
+		name: initialName,
+	});
+
+	return {
+		subscribe,
+		// 로그인 처리 + 토큰 저장
+		login: (token: string, name: string) => {
+			if (browser) {
+				localStorage.setItem(TOKEN_KEY, token);
+				localStorage.setItem(NAME_KEY, name);
+			}
+			update((state) => ({
+				...state,
+				isLoggedIn: true,
+				accessToken: token,
+				name: name,
+			}));
+		},
+		// 토큰 제거 + 로그인 상태 false
+		logout: () => {
+			if (browser) {
+				localStorage.removeItem(TOKEN_KEY);
+				localStorage.removeItem(NAME_KEY);
+			}
+			set({
+				isLoggedIn: false,
+				accessToken: null,
+				name: null,
+			});
+		},
+		// 로그인한 사용자 정보 저장
+		setUser: (name: string) => {
+			update((state) => ({
+				...state,
+				name: name,
+			}));
+		},
+		// 로그인은 유지하되, 사용자 정보만 초기화
+		clearUser: () => {
+			update((state) => ({
+				...state,
+				name: null,
+			}));
+		}
+	};
+}
+
+export const auth = createAuthStore();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,28 @@
+export type AuthState = {
+	isLoggedIn: boolean;
+	accessToken: string | null;
+	name: string | null;
+}
+
+export type LoginPayload = {
+	username: string;
+	password: string;
+}
+
+export type SignUpPayload = {
+	username: string;
+	email: string;
+	password: string;
+	confirmPassword: string;
+}
+
+export type Post = {
+	id: number;
+	user_name: string;
+	game_name: string;
+	during_time: number;
+	participant_num: number;
+	subject: string;
+	content?: string | null;
+	picture?: string | null;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,61 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { auth } from '$lib/stores/auth';
+	import { apiURL } from '$lib/config';
+	import type { Post } from '$lib/types';
+
+	let posts: Post[] = []; // 게시글 목록
+	let isLoading = true;
+
+	onMount(async () => {
+		try {
+			const res = await fetch(apiURL['gameLog']['list']);
+			posts = await res.json();
+		} catch (error) {
+			console.error('게시글 불러오기 실패:', error);
+		} finally {
+			isLoading = false;
+		}
+	});
+
+	const handleLogout = () => {
+		auth.logout();
+	};
+</script>
+
+<header class="flex justify-between items-center p-4 border-b">
+	<h1 class="text-2xl font-bold">메인 페이지</h1>
+	<div>
+		{#if $auth.isLoggedIn}
+			<span class="mr-4">{$auth.name}님 환영합니다!</span>
+			<button on:click={handleLogout} class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
+				로그아웃
+			</button>
+		{:else}
+			<a href="/login" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 mr-2">
+				로그인
+			</a>
+			<a href="/signup" class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
+				회원가입
+			</a>
+		{/if}
+	</div>
+</header>
+
+<main class="p-4">
+	{#if isLoading}
+		<p>게시글을 불러오는 중...</p>
+	{:else if posts.length === 0}
+		<p>게시글이 없습니다.</p>
+	{:else}
+		<ul class="space-y-4">
+			{#each posts as post (post.id)}
+				<li class="p-4 border rounded shadow">
+					<h2 class="text-xl font-semibold">{post.subject}</h2>
+					<p class="text-gray-600">{post.content}</p>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</main>
+

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { auth } from '$lib/stores/auth';
-	import { apiURL } from '$lib/config';
+	import { getLogs } from '$lib/api/logs';
 	import type { Post } from '$lib/types';
 
 	let posts: Post[] = []; // 게시글 목록
@@ -9,8 +9,7 @@
 
 	onMount(async () => {
 		try {
-			const res = await fetch(apiURL['gameLog']['list']);
-			posts = await res.json();
+			posts = await getLogs();
 		} catch (error) {
 			console.error('게시글 불러오기 실패:', error);
 		} finally {
@@ -24,7 +23,7 @@
 </script>
 
 <header class="flex justify-between items-center p-4 border-b">
-	<h1 class="text-2xl font-bold">메인 페이지</h1>
+	<h1 class="text-2xl font-bold">Board Game Logs</h1>
 	<div>
 		{#if $auth.isLoggedIn}
 			<span class="mr-4">{$auth.name}님 환영합니다!</span>
@@ -51,7 +50,9 @@
 		<ul class="space-y-4">
 			{#each posts as post (post.id)}
 				<li class="p-4 border rounded shadow">
-					<h2 class="text-xl font-semibold">{post.subject}</h2>
+					<h2 class="text-xl font-semibold">
+						<a href={`/posts/${post.id}`} class="text-blue-500 hover:underline">{post.subject}</a>
+					</h2>
 					<p class="text-gray-600">{post.content}</p>
 				</li>
 			{/each}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,36 +1,17 @@
 <script lang="ts">
 	import AuthForm from '$lib/components/AuthForm.svelte';
-	import { apiURL } from '$lib/config';
+	import { login } from '$lib/api/auth';
+	import { goto } from '$app/navigation';
+	import type { LoginPayload } from '$lib/types';
 
-	interface LoginPayload {
-		username: string;
-		password: string;
-	}
-
-	function handleLogin({ username, password }: LoginPayload) {
-		const formData = new FormData();
-		formData.append('username', username);
-		formData.append('password', password);
-
-		fetch(apiURL.user.login, {
-			method: 'POST',
-			body: formData
-		})
-			.then(async res => {
-				const data = await res.json();
-				if (!res.ok) throw new Error(data);
-				return data;
-			})
-			.then(data => {
-				console.log('로그인 성공!', data);
-				// 예: 토큰 저장 및 페이지 이동
-			})
-			.catch(err => {
-				console.log("error: ", err);
-				const errMsg = "로그인 실패!"
-				alert(errMsg);
-				console.error(errMsg);
-			});
+	async function handleLogin(payload: LoginPayload) {
+		try {
+			await login(payload);
+			await goto('/');
+		} catch (err) {
+			alert('로그인 실패');
+			console.error(err);
+		}
 	}
 </script>
 

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import AuthForm from '$lib/components/AuthForm.svelte';
+	import { apiURL } from '$lib/config';
+
+	interface LoginPayload {
+		username: string;
+		password: string;
+	}
+
+	function handleLogin({ username, password }: LoginPayload) {
+		const formData = new FormData();
+		formData.append('username', username);
+		formData.append('password', password);
+
+		fetch(apiURL.user.login, {
+			method: 'POST',
+			body: formData
+		})
+			.then(async res => {
+				const data = await res.json();
+				if (!res.ok) throw new Error(data);
+				return data;
+			})
+			.then(data => {
+				console.log('로그인 성공!', data);
+				// 예: 토큰 저장 및 페이지 이동
+			})
+			.catch(err => {
+				console.log("error: ", err);
+				const errMsg = "로그인 실패!"
+				alert(errMsg);
+				console.error(errMsg);
+			});
+	}
+</script>
+
+<AuthForm type="login" onSubmit={handleLogin} />

--- a/src/routes/posts/[postId]/+page.svelte
+++ b/src/routes/posts/[postId]/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import type { Post } from '$lib/types';
+	export let data: { post: Post };
+</script>
+
+<main class="max-w-3xl mx-auto p-6 bg-white rounded shadow">
+	<h1 class="text-3xl font-bold mb-4">{data.post.subject}</h1>
+
+	<ul class="text-gray-700 mb-6 space-y-1">
+		<li><strong>작성자:</strong> {data.post.user_name}</li>
+		<li><strong>게임 이름:</strong> {data.post.game_name}</li>
+		<li><strong>소요 시간:</strong> {data.post.during_time}분</li>
+		<li><strong>참여 인원:</strong> {data.post.participant_num}명</li>
+	</ul>
+
+	{#if data.post.picture}
+		<img src={data.post.picture} alt="게임 사진" class="w-full h-auto rounded mb-4" />
+	{/if}
+
+	{#if data.post.content}
+		<div class="prose max-w-none">
+			<p>{data.post.content}</p>
+		</div>
+	{/if}
+</main>

--- a/src/routes/posts/[postId]/+page.ts
+++ b/src/routes/posts/[postId]/+page.ts
@@ -1,0 +1,8 @@
+import type { Load } from '@sveltejs/kit';
+import type { Post } from '$lib/types';
+import { getParticularLog } from '$lib/api/logs';
+
+export const load: Load = async ({ params }) => {
+	const post: Post = await getParticularLog(params.postId);
+	return { post };
+};

--- a/src/routes/signup/+page.svelte
+++ b/src/routes/signup/+page.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import AuthForm from '$lib/components/AuthForm.svelte';
+	import { apiURL } from '$lib/config';
+
+	interface SignUpPayload {
+		username: string;
+		email: string;
+		password: string;
+		confirmPassword: string;
+	}
+
+	function handleSignUp({ username, email, password, confirmPassword }: SignUpPayload) {
+		const jsonData = {
+			'name': username,
+			'email': email,
+			'password': password,
+			'check_password': confirmPassword
+		};
+
+		fetch(apiURL.user.signup, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify(jsonData)
+		})
+			.then(async res => {
+				const data = await res.json();
+				if (!res.ok) throw new Error(data);
+				return data;
+			})
+			.then(data => {
+				console.log('회원가입 성공!', data);
+				// 예: 토큰 저장 및 페이지 이동
+			})
+			.catch(err => {
+				console.log("error: ", err);
+				const errMsg = "회원가입 실패"
+				alert(errMsg);
+				console.error(errMsg);
+			});
+	}
+</script>
+
+<AuthForm type="signup" onSubmit={handleSignUp} />

--- a/src/routes/signup/+page.svelte
+++ b/src/routes/signup/+page.svelte
@@ -1,44 +1,17 @@
 <script lang="ts">
 	import AuthForm from '$lib/components/AuthForm.svelte';
-	import { apiURL } from '$lib/config';
+	import { signup } from '$lib/api/auth';
+	import { goto } from '$app/navigation';
+	import type { SignUpPayload } from '$lib/types';
 
-	interface SignUpPayload {
-		username: string;
-		email: string;
-		password: string;
-		confirmPassword: string;
-	}
-
-	function handleSignUp({ username, email, password, confirmPassword }: SignUpPayload) {
-		const jsonData = {
-			'name': username,
-			'email': email,
-			'password': password,
-			'check_password': confirmPassword
-		};
-
-		fetch(apiURL.user.signup, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json'
-			},
-			body: JSON.stringify(jsonData)
-		})
-			.then(async res => {
-				const data = await res.json();
-				if (!res.ok) throw new Error(data);
-				return data;
-			})
-			.then(data => {
-				console.log('회원가입 성공!', data);
-				// 예: 토큰 저장 및 페이지 이동
-			})
-			.catch(err => {
-				console.log("error: ", err);
-				const errMsg = "회원가입 실패"
-				alert(errMsg);
-				console.error(errMsg);
-			});
+	async function handleSignUp(payload: SignUpPayload) {
+		try {
+			await signup(payload);
+			await goto('/login');
+		} catch (err) {
+			alert('회원가입 실패');
+			console.error(err);
+		}
 	}
 </script>
 


### PR DESCRIPTION
### Summary
- #1 
- 회원가입, 로그인, 메인 페이지 구현
- 게시글 기본 내용만 조회가능하도록 구현

### Describe

#### 1. 기본 동작
- access token, 이름을 저장하는 `stores/auth.ts` 구현
- 백엔드와 통신할 api 요청 동작 구현
- `config.ts` 에 api url 모음

#### 2. 게시글 기본 내용
- `postId` 를 통해 게시글 상세 내용을 표시만 되도록 구현

### TODO
- 게시글 상세 내용 페이지 정돈 및 개발
- 메인페이지에서 게시글 관련 필터 기능 추가